### PR TITLE
Run npm build with babel presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "mocha --require babel-test-hook",
     "test-watch": "mocha --require babel-test-hook -w --watch-extensions json",
     "lint": "eslint src || true",
-    "build": "babel src --out-dir dist"
+    "build": "babel src --out-dir dist --presets=env,stage-2"
   },
   "author": "Index Data",
   "license": "Apache-2.0",


### PR DESCRIPTION
Ripping out `.babelrc` means we have to be explicit about the presets when running `npm build`.